### PR TITLE
Add `mod`, `abs`, `div` to `Pred`

### DIFF
--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -459,7 +459,6 @@ impl<L: SynthLanguage> Ruleset<L> {
         while selected.len() < step_size {
             let popped = self.0.pop();
             if let Some((_, rule)) = popped {
-                println!("popped: {}", rule.name);
                 if rule.is_valid() {
                     selected.add(rule.clone());
                 } else {
@@ -617,13 +616,10 @@ impl<L: SynthLanguage> Ruleset<L> {
     ///         1. select the best rule candidate
     ///         2. filter out candidates that are redundant given the addition of the selected rule
     pub fn minimize(&mut self, prior: Ruleset<L>, scheduler: Scheduler) -> (Self, Self) {
-        println!("hi minimize: {}", self.len());
         let mut invalid: Ruleset<L> = Default::default();
         let mut chosen = prior.clone();
         let step_size = 1;
-        println!("about to minimize");
         while !self.is_empty() {
-            println!("hi minimize loop: {}", self.len());
             let selected = self.select(step_size, &mut invalid);
             // assert_eq!(selected.len(), 1); <-- wasn't this here in ruler?
             chosen.extend(selected.clone());

--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -594,9 +594,8 @@ impl<L: SynthLanguage> Ruleset<L> {
         println!("candidates : {}", self.len());
         while !self.is_empty() {
             let selected = self.select(step_size, &mut invalid);
-            // assert_eq!(selected.len(), 1);
             // TODO: why do I need this here? what does it mean when `self.select` returns nothing?
-            if selected.len() == 0 {
+            if selected.is_empty() {
                 continue;
             }
             chosen.extend(selected.clone());

--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -594,6 +594,7 @@ impl<L: SynthLanguage> Ruleset<L> {
         while !self.is_empty() {
             let selected = self.select(step_size, &mut invalid);
             // TODO: why do I need this here? what does it mean when `self.select` returns nothing?
+            // See #10.
             if selected.is_empty() {
                 continue;
             }

--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -1,6 +1,4 @@
-use egg::{
-    AstSize, EClass, Extractor, Pattern, RecExpr,
-};
+use egg::{AstSize, EClass, Extractor, Pattern, RecExpr};
 use indexmap::map::{IntoIter, Iter, IterMut, Values, ValuesMut};
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use std::{collections::HashSet, io::Write, str::FromStr, sync::Arc};
@@ -461,6 +459,7 @@ impl<L: SynthLanguage> Ruleset<L> {
         while selected.len() < step_size {
             let popped = self.0.pop();
             if let Some((_, rule)) = popped {
+                println!("popped: {}", rule.name);
                 if rule.is_valid() {
                     selected.add(rule.clone());
                 } else {
@@ -529,7 +528,6 @@ impl<L: SynthLanguage> Ruleset<L> {
                 continue;
             }
 
-            // TODO: can i reset the cache here?
             let new_cond = L::generalize(
                 &RecExpr::from_str(&rule.cond.clone().unwrap().to_string()).unwrap(),
                 &mut Default::default(),
@@ -544,14 +542,8 @@ impl<L: SynthLanguage> Ruleset<L> {
                 .or_insert_with(|| L::condition_implies(&new_cond, &added_cond));
 
             // TODO: @ninehusky: let's use the existing rules to check implications rather than rely on Z3.
+            // See #7.
             if egraph.find(l_id) == egraph.find(r_id) && *implication {
-                // println!("throwing out {}", rule.name);
-                // println!(
-                //     "{} implies {}",
-                //     added_rule.cond.clone().unwrap(),
-                //     rule.cond.clone().unwrap()
-                // );
-                // candidate has merged (derivable from other rewrites)
                 continue;
             } else {
                 will_choose.add(rule);
@@ -599,9 +591,14 @@ impl<L: SynthLanguage> Ruleset<L> {
         let mut invalid: Ruleset<L> = Default::default();
         let mut chosen = prior.clone();
         let step_size = 1;
+        println!("candidates : {}", self.len());
         while !self.is_empty() {
             let selected = self.select(step_size, &mut invalid);
-            assert_eq!(selected.len(), 1);
+            // assert_eq!(selected.len(), 1);
+            // TODO: why do I need this here? what does it mean when `self.select` returns nothing?
+            if selected.len() == 0 {
+                continue;
+            }
             chosen.extend(selected.clone());
             self.shrink_cond(
                 &chosen,
@@ -621,11 +618,15 @@ impl<L: SynthLanguage> Ruleset<L> {
     ///         1. select the best rule candidate
     ///         2. filter out candidates that are redundant given the addition of the selected rule
     pub fn minimize(&mut self, prior: Ruleset<L>, scheduler: Scheduler) -> (Self, Self) {
+        println!("hi minimize: {}", self.len());
         let mut invalid: Ruleset<L> = Default::default();
         let mut chosen = prior.clone();
         let step_size = 1;
+        println!("about to minimize");
         while !self.is_empty() {
+            println!("hi minimize loop: {}", self.len());
             let selected = self.select(step_size, &mut invalid);
+            // assert_eq!(selected.len(), 1); <-- wasn't this here in ruler?
             chosen.extend(selected.clone());
             self.shrink(&chosen, scheduler);
         }

--- a/src/recipe_utils.rs
+++ b/src/recipe_utils.rs
@@ -52,8 +52,11 @@ fn run_workload_internal<L: SynthLanguage>(
         Ruleset::cvec_match(&compressed)
     };
 
+    println!("cvec match done");
+
     let mut chosen: Ruleset<L> = prior.clone();
 
+    println!("minimizing {} candidates...", candidates.len());
     // minimize the total candidates with respect to the prior rules
     let (chosen_total, _) =
         candidates.minimize(prior.clone(), Scheduler::Compress(minimize_limits));
@@ -64,8 +67,11 @@ fn run_workload_internal<L: SynthLanguage>(
 
     if let Some(conditions) = conditions {
         // now, try to add some conditions into tha mix!
+        println!("conditional matching...");
         let mut conditional_candidates =
             Ruleset::conditional_cvec_match(&compressed, &conditions, true);
+
+        println!("minimizing conditions...");
 
         let (chosen_cond, _) = conditional_candidates.minimize_cond(
             chosen.clone(),

--- a/src/recipe_utils.rs
+++ b/src/recipe_utils.rs
@@ -52,11 +52,8 @@ fn run_workload_internal<L: SynthLanguage>(
         Ruleset::cvec_match(&compressed)
     };
 
-    println!("cvec match done");
-
     let mut chosen: Ruleset<L> = prior.clone();
 
-    println!("minimizing {} candidates...", candidates.len());
     // minimize the total candidates with respect to the prior rules
     let (chosen_total, _) =
         candidates.minimize(prior.clone(), Scheduler::Compress(minimize_limits));
@@ -67,11 +64,8 @@ fn run_workload_internal<L: SynthLanguage>(
 
     if let Some(conditions) = conditions {
         // now, try to add some conditions into tha mix!
-        println!("conditional matching...");
         let mut conditional_candidates =
             Ruleset::conditional_cvec_match(&compressed, &conditions, true);
-
-        println!("minimizing conditions...");
 
         let (chosen_cond, _) = conditional_candidates.minimize_cond(
             chosen.clone(),

--- a/tests/recipes/halide.rs
+++ b/tests/recipes/halide.rs
@@ -106,7 +106,7 @@ pub fn halide_rules_for_caviar_conditional() -> Ruleset<Pred> {
         Lang::new(
             &["-1", "0", "1"],
             &["a", "b", "c"],
-            &[&[], &["+", "-", "*", "min", "max"]],
+            &[&[], &["+", "-", "*", "/", "%", "min", "max"]],
         ),
         all_rules.clone(),
         &pvec_to_terms,
@@ -136,7 +136,7 @@ pub fn halide_rules_for_caviar_conditional() -> Ruleset<Pred> {
             &[
                 &["!"],
                 &[
-                    "&&", "||", "+", "-", "*", "min", "max", "<", "<=", "==", "!=",
+                    "&&", "||", "+", "-", "*", "/", "%", "min", "max", "<", "<=", "==", "!=",
                 ],
                 &[],
             ],
@@ -191,7 +191,7 @@ pub fn halide_rules_for_caviar_total_only() -> Ruleset<Pred> {
             &[
                 &["!"],
                 &[
-                    "&&", "||", "+", "-", "*", "min", "max", "<", "<=", "==", "!=",
+                    "&&", "||", "+", "-", "*", "/", "%", "min", "max", "<", "<=", "==", "!=",
                 ],
                 &[],
             ],


### PR DESCRIPTION
Closes #2 .

Note that because [Caviar](https://github.com/caviar-trs/caviar/blob/968f4b1267b6c9a7183a6f722c77b16d9274d385/src/trs/mod.rs#L42) doesn't use rewrite rules with `abs`, I haven't included it in any recipes. But, it does use `abs` in conditions, so we'll use `abs` eventually to create conditional rewrites (see #3).