### PR TITLE
Remove condition implications with unbound variables on RHS

### DIFF
--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -507,7 +507,7 @@ impl<L: SynthLanguage> Ruleset<L> {
         let cond_ast = &L::instantiate(&added_rule.cond.clone().unwrap());
         egraph.add_expr(&format!("(istrue {})", cond_ast).parse().unwrap());
 
-        // 2.5: do condition propogation
+        // 2.5: do condition propagation
         let runner: Runner<L, SynthAnalysis> = Runner::default()
             .with_egraph(egraph.clone())
             .run(prop_rules);
@@ -633,7 +633,7 @@ impl<L: SynthLanguage> Ruleset<L> {
     ///         If derive_type is Lhs, the e-graph is initialized with only lhs
     ///         If derive_type is LhsAndRhs, the e-graph is initialized with lhs and rhs
     ///     2. Add "TRUE" into the e-graph, and union it with the condition.
-    ///     3. Run the condition propogation rules, i.e., set every condition which follows from
+    ///     3. Run the condition propagation rules, i.e., set every condition which follows from
     ///        the given rule's condition to "TRUE".
     ///     4. Run the ruleset
     ///     5. Return true if the lhs and rhs are equivalent, false otherwise.
@@ -760,18 +760,18 @@ impl<L: SynthLanguage> Ruleset<L> {
         derive_type: DeriveType,
         against: &Self,
         limits: Limits,
-        condition_propogation_rules: Option<&Vec<Rewrite<L, SynthAnalysis>>>,
+        condition_propagation_rules: Option<&Vec<Rewrite<L, SynthAnalysis>>>,
     ) -> (Self, Self) {
         against.partition(|rule| {
             if rule.cond.is_some() {
-                if condition_propogation_rules.is_none() {
-                    panic!("Condition propogation rules required for conditional rules. You gave me: {:?}", rule);
+                if condition_propagation_rules.is_none() {
+                    panic!("Condition propagation rules required for conditional rules. You gave me: {:?}", rule);
                 }
                 self.can_derive_cond(
                     derive_type,
                     rule,
                     limits,
-                    condition_propogation_rules.as_ref().unwrap(),
+                    condition_propagation_rules.as_ref().unwrap(),
                 )
             } else {
                 self.can_derive(derive_type, rule, limits)

--- a/src/halide.rs
+++ b/src/halide.rs
@@ -792,7 +792,7 @@ pub fn compute_conditional_structures(
     let egraph: EGraph<Pred, SynthAnalysis> = conditional_soup.to_egraph();
     let mut pvec_to_terms: HashMap<Vec<bool>, Vec<Pattern<Pred>>> = HashMap::default();
 
-    let cond_prop_ruleset = Pred::get_condition_propogation_rules(conditional_soup);
+    let cond_prop_ruleset = Pred::get_condition_propagation_rules(conditional_soup);
 
     for cond in conditional_soup.force() {
         let cond: RecExpr<Pred> = cond.to_string().parse().unwrap();

--- a/src/recipe_utils.rs
+++ b/src/recipe_utils.rs
@@ -38,7 +38,7 @@ fn run_workload_internal<L: SynthLanguage>(
     // pvec -> list of conditions with that pvec
     conditions: Option<HashMap<Vec<bool>, Vec<Pattern<L>>>>,
     // rules for how other conditions become true from other conditions which are true
-    propogation_rules: Option<Vec<Rewrite<L, SynthAnalysis>>>,
+    propagation_rules: Option<Vec<Rewrite<L, SynthAnalysis>>>,
 ) -> Ruleset<L> {
     let t = Instant::now();
     let num_prior = prior.len();
@@ -70,7 +70,7 @@ fn run_workload_internal<L: SynthLanguage>(
         let (chosen_cond, _) = conditional_candidates.minimize_cond(
             chosen.clone(),
             Scheduler::Compress(minimize_limits),
-            &propogation_rules.unwrap(),
+            &propagation_rules.unwrap(),
         );
         chosen.extend(chosen_cond.clone());
     }
@@ -110,7 +110,7 @@ pub fn run_workload<L: SynthLanguage>(
     // pvec -> list of conditions with that pvec
     conditions: Option<HashMap<Vec<bool>, Vec<Pattern<L>>>>,
     // rules for how other conditions become true from other conditions which are true
-    propogation_rules: Option<Vec<Rewrite<L, SynthAnalysis>>>,
+    propagation_rules: Option<Vec<Rewrite<L, SynthAnalysis>>>,
 ) -> Ruleset<L> {
     run_workload_internal(
         workload,
@@ -122,7 +122,7 @@ pub fn run_workload<L: SynthLanguage>(
         true,
         // false,
         conditions,
-        propogation_rules,
+        propagation_rules,
     )
 }
 
@@ -207,7 +207,7 @@ pub fn recursive_rules_cond<L: SynthLanguage>(
     lang: Lang,
     prior: Ruleset<L>,
     conditions: &HashMap<Vec<bool>, Vec<Pattern<L>>>,
-    propogation_rules: &Vec<Rewrite<L, SynthAnalysis>>,
+    propagation_rules: &Vec<Rewrite<L, SynthAnalysis>>,
 ) -> Ruleset<L> {
     if n < 1 {
         Ruleset::default()
@@ -218,7 +218,7 @@ pub fn recursive_rules_cond<L: SynthLanguage>(
             lang.clone(),
             prior.clone(),
             conditions,
-            propogation_rules,
+            propagation_rules,
         );
         let base_lang = if lang.ops.len() == 2 {
             base_lang(2)
@@ -245,7 +245,7 @@ pub fn recursive_rules_cond<L: SynthLanguage>(
             true,
             allow_empty,
             Some(conditions.clone()),
-            Some(propogation_rules.clone()),
+            Some(propagation_rules.clone()),
         );
         let mut all = new;
         all.extend(rec);

--- a/tests/halide.rs
+++ b/tests/halide.rs
@@ -156,7 +156,7 @@ mod test {
         println!("conditions: {:#?}", conditions.len());
 
         let conditional_prop_rules =
-            ruler::halide::Pred::get_condition_propogation_rules(&cond_wkld);
+            ruler::halide::Pred::get_condition_propagation_rules(&cond_wkld);
 
         println!("made it here");
         let (can, cannot) = ruleset.derive(


### PR DESCRIPTION
Through the enumerative search, we were generating (valid) condition implications like: `c1 < -c2 ==> c1 < abs(x)`. I don't think these will mean anything; there will always be a variable-less version that we can enumerate like `c1 < -c2 ==> c1 < 0`.

This PR removes bad implications like the one above.