### PR TITLE
Begin scaling implication finding through keeping egglog path egraph

### DIFF
--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 use std::str::FromStr;
 
 use z3::ast::Ast;
-use egg::Pattern;
+use egg::{Analysis, Applier, Language, Pattern, Rewrite, Var};
 
-use crate::{enumo, SynthLanguage, ValidationResult};
+use crate::{enumo, SynthAnalysis, SynthLanguage, ValidationResult};
 use crate::halide::{Pred, egg_to_z3};
 
 pub mod generate;
@@ -84,4 +84,76 @@ pub fn validate_implication(imp: Implication<Pred>, filter_equalities: bool) -> 
     }
 
 
+}
+
+
+struct EqApplier {
+    a: Var,
+    b: Var,
+}
+
+impl <L: Language, N: Analysis<L>> Applier<L, N> for EqApplier {
+    fn apply_one(
+            &self,
+            egraph: &mut egg::EGraph<L, N>,
+            _eclass: egg::Id,
+            subst: &egg::Subst,
+            _searcher_ast: Option<&egg::PatternAst<L>>,
+            _rule_name: egg::Symbol,
+        ) -> Vec<egg::Id> {
+        let a = subst.get(self.a).unwrap();
+        let b = subst.get(self.b).unwrap();
+        if egraph.union(*a, *b) {
+            vec![*a, *b]
+        } else {
+            vec![]
+        }
+    }
+}
+
+
+pub fn merge_eqs() -> Rewrite<Pred, SynthAnalysis> {
+    let searcher: Pattern<Pred> = "(istrue (== ?a ?b))".parse().unwrap();
+    // union ?a and ?b.
+    let applier = EqApplier {
+        a: "?a".parse().unwrap(),
+        b: "?b".parse().unwrap(),
+    };
+
+    Rewrite::new("istrue-eqs", searcher, applier).unwrap()
+}
+
+pub mod tests {
+    use egg::{EGraph, Runner};
+
+    use crate::{enumo::egg_to_serialized_egraph, ImplicationSwitch};
+
+    use super::*;
+    #[test]
+    fn merge_eqs_merges() {
+        let rule: ImplicationSwitch<Pred> = ImplicationSwitch {
+            parent_cond: "(!= ?x 0)".parse().unwrap(),
+            my_cond: "(== (/ ?x ?x) 1)".parse().unwrap(),
+        };
+
+        let egraph = &mut EGraph::<Pred, SynthAnalysis>::default();
+
+        egraph.add_expr(&"(istrue (!= x 0))".parse().unwrap());
+
+        let runner: Runner<Pred, SynthAnalysis> = Runner::new(SynthAnalysis::default())
+            .with_egraph(egraph.clone())
+            .run(&[rule.rewrite(), merge_eqs()]);
+
+    let egraph = runner.egraph.clone();
+
+    let serialized = egg_to_serialized_egraph(&egraph);
+    serialized.to_json_file("implication_toggle_equality_simple.json").unwrap();
+
+
+    assert!(egraph.lookup_expr(&"(istrue (== (/ x x) 1))".parse().unwrap()).is_some());
+
+    assert_eq!(egraph.lookup_expr(&"(/ x x)".parse().unwrap()), egraph.lookup_expr(&"1".parse().unwrap()));
+
+
+    }
 }

--- a/src/enumo/rule.rs
+++ b/src/enumo/rule.rs
@@ -184,6 +184,13 @@ impl<L: SynthLanguage> Rule<L> {
     pub fn new_cond(l_pat: &Pattern<L>, r_pat: &Pattern<L>, cond_pat: &Pattern<L>) -> Option<Self> {
         let name = format!("{} ==> {} if {}", l_pat, r_pat, cond_pat);
 
+        let cond_vars = cond_pat.vars();
+        let l_vars = l_pat.vars();
+
+        if cond_vars.iter().any(|v| !l_vars.contains(v)) {
+            return None; // Condition variables must be a subset of the left-hand side variables
+        }
+
         let rewrite = Rewrite::new(
             name.clone(),
             l_pat.clone(),

--- a/src/halide.rs
+++ b/src/halide.rs
@@ -2,6 +2,7 @@ use crate::{enumo::Rule, *};
 
 use egg::{RecExpr, Rewrite};
 use enumo::{Filter, Metric, Ruleset, Sexp, Workload};
+use log::log;
 use num::ToPrimitive;
 use recipe_utils::{
     base_lang, iter_metric, recursive_rules, recursive_rules_cond, run_workload, Lang,
@@ -961,6 +962,7 @@ pub fn recipe_to_rules(recipes: &Vec<Recipe>) -> Ruleset<Pred> {
 }
 
 pub fn og_recipe() -> Ruleset<Pred> {
+    log::info!("LOG: Starting recipe.");
     let mut wkld = conditions::generate::get_condition_workload();
 
     // only want conditions greater than size 2
@@ -968,36 +970,6 @@ pub fn og_recipe() -> Ruleset<Pred> {
 
     let (pvec_to_terms, mut cond_prop_ruleset) = conditions::generate::get_condition_propagation_rules_halide(&wkld);
     let mut all_rules = Ruleset::default();
-
-    cond_prop_ruleset.push( 
-        ImplicationSwitch::new(
-            &"(&& ?a ?b)".parse().unwrap(),
-            &"?a".parse().unwrap()
-        ).rewrite()
-    );
-
-    cond_prop_ruleset.push( 
-        ImplicationSwitch::new(
-            &"(&& ?a ?b)".parse().unwrap(),
-            &"?b".parse().unwrap()
-        ).rewrite()
-    );
-
-    // add that `(&& (<= ?a ?c) (<= ?b ?c))` `
-
-    // println!("terms:");
-    // for v in pvec_to_terms.values() {
-    //     for t in v {
-    //         println!("{}", t);
-    //     }
-    // }
-
-    // println!("implication rules:");
-
-    // for r in cond_prop_ruleset {
-    //     println!("{}", r.name);
-    // }
-
 
     let equality = recursive_rules(
         Metric::Atoms,
@@ -1073,7 +1045,6 @@ pub fn og_recipe() -> Ruleset<Pred> {
     // the special workloads, which mostly revolve around
     // composing int2boolop(int_term, int_term) or things like that
     // together.
-    //
     let int_lang = Lang::new(&[], &["a", "b", "c"], &[&[], &["+", "-", "*", "min", "max"]]);
     let mut int_wkld = iter_metric(crate::recipe_utils::base_lang(2), "EXPR", Metric::Atoms, 3)
         .filter(Filter::Contains("VAR".parse().unwrap()))


### PR DESCRIPTION
Allows for larger condition grammars; implication finding is done through tracking a condition e-graph.

Also begins to filter out redundant conditional candidates (optimization 2).

Closes #65.