### PR TITLE
Limit conditions to be considered in ascending size

### DIFF
--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -164,9 +164,7 @@ impl<L: SynthLanguage> Ruleset<L> {
         let cond = Assumption::new(L::generalize(cond, map).to_string()).unwrap();
         let forward = Rule::new_cond(&l_pat, &r_pat, &cond, Some(true_count));
         let backward = Rule::new_cond(&r_pat, &l_pat, &cond, Some(true_count));
-        println!(
-            "[add_cond_from_recexprs] Adding rule candidate: {l_pat} ==> {r_pat} if {cond}"
-        );
+        println!("[add_cond_from_recexprs] Adding rule candidate: {l_pat} ==> {r_pat} if {cond}");
         if let Some(forward) = forward {
             self.add(forward);
         }

--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -164,6 +164,10 @@ impl<L: SynthLanguage> Ruleset<L> {
         let cond = Assumption::new(L::generalize(cond, map).to_string()).unwrap();
         let forward = Rule::new_cond(&l_pat, &r_pat, &cond, Some(true_count));
         let backward = Rule::new_cond(&r_pat, &l_pat, &cond, Some(true_count));
+        println!(
+            "[add_cond_from_recexprs] Adding rule candidate: {} ==> {} if {}",
+            l_pat, r_pat, cond
+        );
         if let Some(forward) = forward {
             self.add(forward);
         }
@@ -476,7 +480,7 @@ impl<L: SynthLanguage> Ruleset<L> {
         if l_id == r_id {
             // e1 and e2 are equivalent in the condition egraph
             println!(
-                "Skipping {} and {} because they are equivalent in the egraph representing {}",
+                "[conditional_cvec_match] Skipping {} and {} because they are equivalent in the egraph representing {}",
                 l_expr, r_expr, cond.pat
             );
             return None;

--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -165,8 +165,7 @@ impl<L: SynthLanguage> Ruleset<L> {
         let forward = Rule::new_cond(&l_pat, &r_pat, &cond, Some(true_count));
         let backward = Rule::new_cond(&r_pat, &l_pat, &cond, Some(true_count));
         println!(
-            "[add_cond_from_recexprs] Adding rule candidate: {} ==> {} if {}",
-            l_pat, r_pat, cond
+            "[add_cond_from_recexprs] Adding rule candidate: {l_pat} ==> {r_pat} if {cond}"
         );
         if let Some(forward) = forward {
             self.add(forward);

--- a/src/halide.rs
+++ b/src/halide.rs
@@ -12,7 +12,7 @@ use conditions::implication_set::ImplicationSet;
 use egg::{RecExpr, Rewrite};
 use enumo::{Filter, Metric, Ruleset, Sexp, Workload};
 use num::ToPrimitive;
-use recipe_utils::{recursive_rules, recursive_rules_cond, run_workload, Lang};
+use recipe_utils::{recursive_rules_cond, run_workload, Lang};
 use z3::ast::Ast;
 
 type Constant = i64;

--- a/src/halide.rs
+++ b/src/halide.rs
@@ -1024,40 +1024,40 @@ pub fn og_recipe() -> Ruleset<Pred> {
     // here, make sure wkld is non empty
     assert_ne!(wkld, Workload::empty());
 
-    let and_rules = recursive_rules(
-        Metric::Atoms,
-        5,
-        Lang::new(
-            &["0", "1"],
-            &["a", "b", "c"],
-            &[&[], &["&&", "||", "==", "!="]],
-        ),
-        Ruleset::default(),
-    );
+    // let and_rules = recursive_rules(
+    //     Metric::Atoms,
+    //     5,
+    //     Lang::new(
+    //         &["0", "1"],
+    //         &["a", "b", "c"],
+    //         &[&[], &["&&", "||", "==", "!="]],
+    //     ),
+    //     Ruleset::default(),
+    // );
 
-    all_rules.extend(and_rules.clone());
+    // all_rules.extend(and_rules.clone());
 
-    let comps = Workload::new(&["(OP V V)"])
-        .plug("OP", &Workload::new(&["=="]))
-        .plug("V", &Workload::new(&["a", "b", "c"]));
+    // let comps = Workload::new(&["(OP V V)"])
+    //     .plug("OP", &Workload::new(&["=="]))
+    //     .plug("V", &Workload::new(&["a", "b", "c"]));
 
-    let and_workload = Workload::new(&["0", "1", "(OP V V)"])
-        .plug("OP", &Workload::new(&["&&"]))
-        .plug("V", &comps);
+    // let and_workload = Workload::new(&["0", "1", "(OP V V)"])
+    //     .plug("OP", &Workload::new(&["&&"]))
+    //     .plug("V", &comps);
 
-    let comp_eq = run_workload(
-        and_workload.clone(),
-        Some(wkld.clone()),
-        all_rules.clone(),
-        base_implications.clone(),
-        Limits::synthesis(),
-        Limits::minimize(),
-        true,
-    );
+    // let comp_eq = run_workload(
+    //     and_workload.clone(),
+    //     Some(wkld.clone()),
+    //     all_rules.clone(),
+    //     base_implications.clone(),
+    //     Limits::synthesis(),
+    //     Limits::minimize(),
+    //     true,
+    // );
 
-    all_rules.extend(comp_eq.clone());
+    // all_rules.extend(comp_eq.clone());
 
-    all_rules.pretty_print();
+    // all_rules.pretty_print();
 
     let arith_basic = recursive_rules_cond(
         Metric::Atoms,

--- a/src/recipe_utils.rs
+++ b/src/recipe_utils.rs
@@ -4,7 +4,7 @@ use egg::EGraph;
 
 use crate::{
     conditions::implication_set::ImplicationSet,
-    enumo::{ChompyState, Filter, Metric, Ruleset, Scheduler, Workload},
+    enumo::{ChompyState, Filter, Metric, PredicateMap, Ruleset, Scheduler, Workload},
     Limits, SynthAnalysis, SynthLanguage,
 };
 
@@ -80,18 +80,30 @@ fn run_workload_internal<L: SynthLanguage>(
     let impl_prop_rules = state.implications();
 
     for cond_size in 1..=max_cond_size {
-        let curr_wkld = cond_workload
-            .clone()
-            .filter(Filter::MetricEq(Metric::Atoms, cond_size + 1));
+        println!("[run_workload] cond size: {}", cond_size);
+        let mut predicates: PredicateMap<L> = Default::default();
 
-        if curr_wkld.force().is_empty() {
+        for pvec in state.pvec_to_patterns().keys() {
+            for pattern in state.pvec_to_patterns().get(pvec).unwrap() {
+                let size = pattern.chop_assumption().ast.as_ref().len();
+                if size == cond_size {
+                    predicates
+                        .entry(pvec.clone())
+                        .or_default()
+                        .push(pattern.clone());
+                }
+            }
+        }
+
+        if predicates.is_empty() {
+            println!("[run_workload] No predicates of size {}", cond_size);
             continue;
         }
 
         let mut conditional_candidates = Ruleset::conditional_cvec_match(
             &compressed,
             &chosen,
-            &state.pvec_to_patterns(),
+            &predicates,
             state.implications(),
         );
 

--- a/src/recipe_utils.rs
+++ b/src/recipe_utils.rs
@@ -80,7 +80,7 @@ fn run_workload_internal<L: SynthLanguage>(
     let impl_prop_rules = state.implications();
 
     for cond_size in 1..=max_cond_size {
-        println!("[run_workload] cond size: {}", cond_size);
+        println!("[run_workload] cond size: {cond_size}");
         let mut predicates: PredicateMap<L> = Default::default();
 
         for pvec in state.pvec_to_patterns().keys() {
@@ -96,7 +96,7 @@ fn run_workload_internal<L: SynthLanguage>(
         }
 
         if predicates.is_empty() {
-            println!("[run_workload] No predicates of size {}", cond_size);
+            println!("[run_workload] No predicates of size {cond_size}");
             continue;
         }
 


### PR DESCRIPTION
In the future, we can make this check more intelligent; for now, we just fall back on the concept of "larger condition == stronger (more restrictive) condition.

Pseudocode for this change:

```
for size in cond_size:
    # the line below was not properly implemented in main
    conditions = conditions.filter(ast_size = size)

    candidates = egraph.conditional_cvec_match(conditions)
    ...
```