### PR TITLE
And `&&` implication rules back

### DIFF
--- a/src/conditions/assumption.rs
+++ b/src/conditions/assumption.rs
@@ -60,9 +60,7 @@ impl<L: SynthLanguage> Assumption<L> {
     pub fn new_unsafe(assumption: String) -> Result<Self, String> {
         let pat: Result<Pattern<L>, _> = assumption.parse();
         if pat.is_err() {
-            return Err(format!(
-                "Failed to parse assumption pattern: {assumption}"
-            ));
+            return Err(format!("Failed to parse assumption pattern: {assumption}"));
         }
         let pat = pat.unwrap();
         if L::pattern_is_assumption(&pat) {

--- a/src/conditions/assumption.rs
+++ b/src/conditions/assumption.rs
@@ -160,10 +160,23 @@ mod tests {
         );
     }
 
+    // tests that `new_unsafe` does not check if the pattern is a valid predicate.
+    #[test]
+    fn new_unsafe_is_actually_unsafe() {
+        let not_predicate = "?a".to_string();
+        let result: Result<Assumption<Pred>, String> = Assumption::new_unsafe(not_predicate);
+        println!("{:?}", result);
+        assert!(
+            result.is_ok(),
+            "Expected new_unsafe to succeed even if not a predicate"
+        );
+    }
+
     #[test]
     fn test_assumption_fail_unparsable() {
         let invalid_assumption_str = "(invalid x 0)".to_string();
-        let result: Result<Assumption<Pred>, String> = Assumption::new(invalid_assumption_str);
+        let result: Result<Assumption<Pred>, String> =
+            Assumption::new_unsafe(invalid_assumption_str);
         assert!(
             result.is_err(),
             "Expected error for invalid assumption pattern"

--- a/src/conditions/assumption.rs
+++ b/src/conditions/assumption.rs
@@ -61,13 +61,12 @@ impl<L: SynthLanguage> Assumption<L> {
         let pat: Result<Pattern<L>, _> = assumption.parse();
         if pat.is_err() {
             return Err(format!(
-                "Failed to parse assumption pattern: {}",
-                assumption
+                "Failed to parse assumption pattern: {assumption}"
             ));
         }
         let pat = pat.unwrap();
         if L::pattern_is_assumption(&pat) {
-            return Err(format!("Pattern is already an assumption: {}", pat));
+            return Err(format!("Pattern is already an assumption: {pat}"));
         }
 
         Ok(Self {
@@ -165,7 +164,7 @@ mod tests {
     fn new_unsafe_is_actually_unsafe() {
         let not_predicate = "?a".to_string();
         let result: Result<Assumption<Pred>, String> = Assumption::new_unsafe(not_predicate);
-        println!("{:?}", result);
+        println!("{result:?}");
         assert!(
             result.is_ok(),
             "Expected new_unsafe to succeed even if not a predicate"

--- a/src/conditions/assumption.rs
+++ b/src/conditions/assumption.rs
@@ -54,6 +54,28 @@ impl<L: SynthLanguage> Assumption<L> {
         })
     }
 
+    /// Like `new`, but does not check if the pattern is a valid predicate.
+    /// Dangerous! Only call this if you have a very good reason to believe
+    /// the pattern in question is a predicate.
+    pub fn new_unsafe(assumption: String) -> Result<Self, String> {
+        let pat: Result<Pattern<L>, _> = assumption.parse();
+        if pat.is_err() {
+            return Err(format!(
+                "Failed to parse assumption pattern: {}",
+                assumption
+            ));
+        }
+        let pat = pat.unwrap();
+        if L::pattern_is_assumption(&pat) {
+            return Err(format!("Pattern is already an assumption: {}", pat));
+        }
+
+        Ok(Self {
+            pat: assumption,
+            _marker: std::marker::PhantomData,
+        })
+    }
+
     /// Inserts the assumption as an expression into the provided e-graph.
     pub fn insert_into_egraph(&self, egraph: &mut egg::EGraph<L, crate::SynthAnalysis>) {
         let expr: RecExpr<L> = self.clone().into();

--- a/src/conditions/manager.rs
+++ b/src/conditions/manager.rs
@@ -3,10 +3,10 @@ use crate::{
         assumption::Assumption, implication::Implication, implication_set::ImplicationSet,
     },
     enumo::{Rule, Ruleset},
-    SynthLanguage,
+    Symbol, SynthLanguage,
 };
 
-use egg::{Pattern, RecExpr};
+use egg::{Pattern, RecExpr, Var};
 use egglog::EGraph as EgglogEGraph;
 
 const IMPL_RULESET_NAME: &str = "path-finding";
@@ -201,6 +201,20 @@ impl<L: SynthLanguage> EGraphManager<L> {
     /// Implications should **never** add new predicates to the egraph; it should only
     /// link together existing ones.
     fn impl_to_egglog_rule(imp: &Implication<L>) -> Result<String, String> {
+        // This is a hack to deal with the "and" rule:
+        // the rule is that (&& a b) -> a, for example, meaning that "a" doesn't
+        // need to be a predicate. Moreover, we can't have an egglog rule that just
+        // matches on "?a", so we need to just omit it in the egglog fact body.
+        let get_term = |pat: &Pattern<L>| -> String {
+            if pat.ast.as_ref().len() == 1
+                && matches!(pat.ast.as_ref().first().unwrap(), egg::ENodeOrVar::Var(_))
+            {
+                "".into()
+            } else {
+                L::to_egglog_term(pat.clone())
+            }
+        };
+
         let lhs = imp.lhs().clone();
         let rhs = imp.rhs().clone();
 
@@ -217,19 +231,27 @@ impl<L: SynthLanguage> EGraphManager<L> {
 
         let lhs_recexpr: RecExpr<L> = L::instantiate(&imp.lhs().clone().chop_assumption());
         let rhs_recexpr: RecExpr<L> = L::instantiate(&imp.rhs().clone().chop_assumption());
-
         let mut map = Default::default();
+        let lhs_pat = L::generalize(&lhs_recexpr, &mut map);
+        let rhs_pat = L::generalize(&rhs_recexpr, &mut map);
 
-        let lhs = L::to_egglog_term(L::generalize(&lhs_recexpr, &mut map));
-        let rhs = L::to_egglog_term(L::generalize(&rhs_recexpr, &mut map));
+        let lhs_fact = get_term(&lhs_pat);
+        let rhs_fact = get_term(&rhs_pat);
+        let lhs = L::to_egglog_term(lhs_pat);
+        let rhs = L::to_egglog_term(rhs_pat);
+
+        if lhs_fact == "" && rhs_fact == "" {
+            return Err("Implication seems to be over two non-predicate terms".into());
+        }
+
         // sanity check: there should be no concrete variables in the lhs or rhs.
         // if you're able to match on lhs, rhs, draw an edge between them.
         let rs_name = IMPL_RULESET_NAME;
         Ok(format!(
             r#"
         (rule
-            ({lhs}
-             {rhs})
+            ({lhs_fact}
+             {rhs_fact})
             ((edge {lhs} {rhs}))
             :ruleset {rs_name})
         "#,

--- a/src/conditions/manager.rs
+++ b/src/conditions/manager.rs
@@ -2,11 +2,10 @@ use crate::{
     conditions::{
         assumption::Assumption, implication::Implication, implication_set::ImplicationSet,
     },
-    enumo::{Rule, Ruleset},
-    Symbol, SynthLanguage,
+    enumo::{Rule, Ruleset}, SynthLanguage,
 };
 
-use egg::{Pattern, RecExpr, Var};
+use egg::{Pattern, RecExpr};
 use egglog::EGraph as EgglogEGraph;
 
 const IMPL_RULESET_NAME: &str = "path-finding";
@@ -240,7 +239,7 @@ impl<L: SynthLanguage> EGraphManager<L> {
         let lhs = L::to_egglog_term(lhs_pat);
         let rhs = L::to_egglog_term(rhs_pat);
 
-        if lhs_fact == "" && rhs_fact == "" {
+        if lhs_fact.is_empty() && rhs_fact.is_empty() {
             return Err("Implication seems to be over two non-predicate terms".into());
         }
 

--- a/src/conditions/manager.rs
+++ b/src/conditions/manager.rs
@@ -2,7 +2,8 @@ use crate::{
     conditions::{
         assumption::Assumption, implication::Implication, implication_set::ImplicationSet,
     },
-    enumo::{Rule, Ruleset}, SynthLanguage,
+    enumo::{Rule, Ruleset},
+    SynthLanguage,
 };
 
 use egg::{Pattern, RecExpr};

--- a/src/enumo/rule.rs
+++ b/src/enumo/rule.rs
@@ -313,7 +313,7 @@ mod test {
 
     use crate::enumo::{Rule, Ruleset};
 
-    use crate::language::{SynthAnalysis, SynthLanguage};
+    use crate::language::SynthAnalysis;
 
     use super::halide::Pred;
     use super::ImplicationSwitch;

--- a/src/halide.rs
+++ b/src/halide.rs
@@ -1019,7 +1019,24 @@ pub fn og_recipe() -> Ruleset<Pred> {
     let start_time = std::time::Instant::now();
     let wkld = conditions::generate::get_condition_workload();
     let mut all_rules = Ruleset::default();
-    let base_implications = ImplicationSet::default();
+    let mut base_implications = ImplicationSet::default();
+    // and the "and" rules here.
+    let and_implies_left: Implication<Pred> = Implication::new(
+        "and_implies_left".into(),
+        Assumption::new("(&& ?a ?b)".to_string()).unwrap(),
+        Assumption::new_unsafe("?a".to_string()).unwrap(),
+    )
+    .unwrap();
+
+    let and_implies_right: Implication<Pred> = Implication::new(
+        "and_implies_right".into(),
+        Assumption::new("(&& ?a ?b)".to_string()).unwrap(),
+        Assumption::new_unsafe("?b".to_string()).unwrap(),
+    )
+    .unwrap();
+
+    base_implications.add(and_implies_left);
+    base_implications.add(and_implies_right);
 
     // here, make sure wkld is non empty
     assert_ne!(wkld, Workload::empty());

--- a/src/language.rs
+++ b/src/language.rs
@@ -25,8 +25,8 @@ use crate::{
 // in the e-graph through adding the term `(IsTrue c)`.
 //
 // When the corresponding `ImplicationSwitch` is run (i.e., when it's run as a rule),
-// then it will add `(IsTrue c')` to the e-graph, paving the way for conditional rewrite
-// rules. See `ConditionalRewrite` for more details.
+// then it will add `(assume c')` to the e-graph, paving the way for conditional rewrite
+// rules.
 pub struct ImplicationSwitch<L: SynthLanguage> {
     pub(crate) parent_cond: Pattern<L>,
     pub(crate) my_cond: Pattern<L>,
@@ -630,9 +630,8 @@ pub trait SynthLanguage: Language + Send + Sync + Display + FromOp + 'static {
     }
 }
 
-// run these tests with `cargo test --test implication`
 #[cfg(test)]
-pub mod tests {
+pub mod implication_switch_tests {
     use super::*;
     use crate::halide::Pred;
     use conditions::merge_eqs;


### PR DESCRIPTION
- [x] Change APi for `Assumption` to allow for non-predicates
- [x] Push them through to the Chompy recipe
- [x] Test the relevant changes to `to_egglog_term`: do we fail when given two non-predicates (e.g., `(?a -> ?b)`?)