### PR TITLE
Run condition implication on basic `add_and_comps` rules

### DIFF
--- a/src/halide.rs
+++ b/src/halide.rs
@@ -4,6 +4,7 @@ use crate::{
     conditions::{
         assumption::Assumption,
         implication::{Implication, ImplicationValidationResult},
+        implication_set::run_implication_workload,
     },
     time_fn_call, *,
 };
@@ -1037,6 +1038,18 @@ pub fn og_recipe() -> Ruleset<Pred> {
 
     base_implications.add(and_implies_left);
     base_implications.add(and_implies_right);
+
+    let other_implications = time_fn_call!(
+        "find_base_implications",
+        run_implication_workload(
+            &wkld,
+            &["a".to_string(), "b".to_string(), "c".to_string()],
+            &base_implications,
+            &Default::default()
+        )
+    );
+
+    base_implications.add_all(other_implications);
 
     // here, make sure wkld is non empty
     assert_ne!(wkld, Workload::empty());

--- a/src/halide.rs
+++ b/src/halide.rs
@@ -1051,6 +1051,11 @@ pub fn og_recipe() -> Ruleset<Pred> {
 
     base_implications.add_all(other_implications);
 
+    println!("# base implications: {}", base_implications.len());
+
+    for i in base_implications.iter() {
+        println!("implication: {}", i.name());
+    }
     // here, make sure wkld is non empty
     assert_ne!(wkld, Workload::empty());
 

--- a/src/halide.rs
+++ b/src/halide.rs
@@ -5,7 +5,7 @@ use crate::{
         assumption::Assumption,
         implication::{Implication, ImplicationValidationResult},
     },
-    *,
+    time_fn_call, *,
 };
 
 use conditions::implication_set::ImplicationSet;
@@ -1041,49 +1041,61 @@ pub fn og_recipe() -> Ruleset<Pred> {
     // here, make sure wkld is non empty
     assert_ne!(wkld, Workload::empty());
 
-    let simp_comps = recursive_rules_cond(
-        Metric::Atoms,
-        5,
-        Lang::new(&["0", "1"], &["a", "b", "c"], &[&[], &["<", ">", "+", "-"]]),
-        Ruleset::default(),
-        base_implications.clone(),
-        wkld.clone(),
+    let simp_comps = time_fn_call!(
+        "simp_comps",
+        recursive_rules_cond(
+            Metric::Atoms,
+            5,
+            Lang::new(&["0", "1"], &["a", "b", "c"], &[&[], &["<", ">", "+", "-"]]),
+            Ruleset::default(),
+            base_implications.clone(),
+            wkld.clone(),
+        )
     );
 
     all_rules.extend(simp_comps.clone());
 
-    let arith_basic = recursive_rules_cond(
-        Metric::Atoms,
-        5,
-        Lang::new(
-            &["0", "1"],
-            &["a", "b", "c"],
-            &[&["-"], &["+", "-", "*", "/"]],
-        ),
-        Ruleset::default(),
-        base_implications.clone(),
-        wkld.clone(),
+    let arith_basic = time_fn_call!(
+        "arith_basic",
+        recursive_rules_cond(
+            Metric::Atoms,
+            5,
+            Lang::new(
+                &["0", "1"],
+                &["a", "b", "c"],
+                &[&["-"], &["+", "-", "*", "/"]],
+            ),
+            Ruleset::default(),
+            base_implications.clone(),
+            wkld.clone(),
+        )
     );
     all_rules.extend(arith_basic.clone());
 
-    let min_max = recursive_rules_cond(
-        Metric::Atoms,
-        7,
-        Lang::new(&[], &["a", "b", "c"], &[&[], &["min", "max"]]),
-        all_rules.clone(),
-        base_implications.clone(),
-        wkld.clone(),
+    let min_max = time_fn_call!(
+        "min_max",
+        recursive_rules_cond(
+            Metric::Atoms,
+            7,
+            Lang::new(&[], &["a", "b", "c"], &[&[], &["min", "max"]]),
+            all_rules.clone(),
+            base_implications.clone(),
+            wkld.clone(),
+        )
     );
 
     all_rules.extend(min_max.clone());
 
-    let min_max_add = recursive_rules_cond(
-        Metric::Atoms,
-        5,
-        Lang::new(&["0", "1"], &["a", "b", "c"], &[&[], &["+", "min", "max"]]),
-        all_rules.clone(),
-        base_implications.clone(),
-        wkld.clone(),
+    let min_max_add = time_fn_call!(
+        "min_max_add",
+        recursive_rules_cond(
+            Metric::Atoms,
+            5,
+            Lang::new(&["0", "1"], &["a", "b", "c"], &[&[], &["+", "min", "max"]]),
+            all_rules.clone(),
+            base_implications.clone(),
+            wkld.clone(),
+        )
     );
 
     all_rules.extend(min_max_add.clone());
@@ -1102,26 +1114,32 @@ pub fn og_recipe() -> Ruleset<Pred> {
                 "c".to_string(),
             ]));
 
-        let eq_simp = run_workload(
-            eq_workload,
-            Some(wkld.clone()),
-            min_max.clone(),
-            base_implications.clone(),
-            Limits::synthesis(),
-            Limits::minimize(),
-            true,
+        let eq_simp = time_fn_call!(
+            format!("eq_simp_{}", op),
+            run_workload(
+                eq_workload,
+                Some(wkld.clone()),
+                min_max.clone(),
+                base_implications.clone(),
+                Limits::synthesis(),
+                Limits::minimize(),
+                true,
+            )
         );
 
         all_rules.extend(eq_simp);
     }
 
-    let min_max_mul = recursive_rules_cond(
-        Metric::Atoms,
-        7,
-        Lang::new(&[], &["a", "b", "c"], &[&[], &["min", "max", "*"]]),
-        all_rules.clone(),
-        base_implications.clone(),
-        wkld.clone(),
+    let min_max_mul = time_fn_call!(
+        "min_max_mul",
+        recursive_rules_cond(
+            Metric::Atoms,
+            7,
+            Lang::new(&[], &["a", "b", "c"], &[&[], &["min", "max", "*"]]),
+            all_rules.clone(),
+            base_implications.clone(),
+            wkld.clone(),
+        )
     );
 
     all_rules.extend(min_max_mul);

--- a/src/halide.rs
+++ b/src/halide.rs
@@ -166,9 +166,9 @@ impl SynthLanguage for Pred {
                         Sexp::Atom(format!("(Lit {num})"))
                     } else if a.starts_with("?") {
                         // a is a meta-variable, leave it alone.
-                        return Sexp::Atom(a.into());
+                        Sexp::Atom(a.into())
                     } else {
-                        return Sexp::Atom(format!("(Var \"{a}\")"));
+                        Sexp::Atom(format!("(Var \"{a}\")"))
                     }
                 }
                 Sexp::List(l) => {

--- a/src/recipe_utils.rs
+++ b/src/recipe_utils.rs
@@ -8,6 +8,23 @@ use crate::{
     Limits, SynthAnalysis, SynthLanguage,
 };
 
+// A cute lil' macro to time function calls.
+#[macro_export]
+macro_rules! time_fn_call {
+    ($label:expr, $fn_call:expr) => {{
+        use std::time::Instant;
+        let start = Instant::now();
+        let result = $fn_call;
+        let duration = start.elapsed();
+        println!(
+            "LOG: Chomp! I finished {} in {} ms.",
+            $label,
+            duration.as_millis()
+        );
+        result
+    }};
+}
+
 /// Iterate a grammar (represented as a workload) up to a certain size metric
 pub fn iter_metric(wkld: Workload, atom: &str, met: Metric, n: usize) -> Workload {
     let mut pegs = wkld.clone();


### PR DESCRIPTION
If this works, then we can merge this basic set into main and just focus on #142.

Before merging:
- [x] Check that derivability didn't break (should have 21 rules derived)
- [x] Sight-check generated implications